### PR TITLE
책 상세 정보 조회 시 지연 로딩 문제

### DIFF
--- a/src/main/java/store/storymate/storymatebackend/reading/api/dto/response/BookDetailResponse.java
+++ b/src/main/java/store/storymate/storymatebackend/reading/api/dto/response/BookDetailResponse.java
@@ -14,11 +14,7 @@ public record BookDetailResponse(
         String keyword,
         String description
 ) {
-    public static BookDetailResponse fromEntity(Book book) {
-        String tags = "";
-        book.getBookTags().forEach(bookTag -> {
-            "%s%s".formatted(tags, bookTag.getTag().getName());
-        });
+    public static BookDetailResponse fromEntity(Book book, String tags) {
         return BookDetailResponse.builder()
                 .id(book.getId())
                 .title(book.getTitle())

--- a/src/main/java/store/storymate/storymatebackend/reading/application/BookServiceImpl.java
+++ b/src/main/java/store/storymate/storymatebackend/reading/application/BookServiceImpl.java
@@ -3,15 +3,14 @@ package store.storymate.storymatebackend.reading.application;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import store.storymate.storymatebackend.reading.api.dto.BookCriteria;
 import store.storymate.storymatebackend.reading.api.dto.PageInfoDto;
 import store.storymate.storymatebackend.reading.api.dto.response.BookDetailResponse;
 import store.storymate.storymatebackend.reading.api.dto.response.BookResponse;
 import store.storymate.storymatebackend.reading.api.dto.response.BookResponseList;
-import store.storymate.storymatebackend.reading.api.dto.BookCriteria;
 import store.storymate.storymatebackend.reading.domain.Book;
 import store.storymate.storymatebackend.reading.domain.repository.BookRepository;
 import store.storymate.storymatebackend.reading.exception.BookNotFoundException;
@@ -35,8 +34,13 @@ public class BookServiceImpl implements BookService {
     @Override
     public BookDetailResponse getBookDetails(Long bookId) {
         Book book = bookRepository.findById(bookId)
-            .orElseThrow(() -> new BookNotFoundException());
-        log.info("book.getBookTags().size() : {}", book.getBookTags().size());
-        return BookDetailResponse.fromEntity(book);
+                .orElseThrow(BookNotFoundException::new);
+        String tags = "";
+        if (book.getBookTags() != null) {
+            tags = book.getBookTags().stream()
+                    .map(bookTag -> "#" + bookTag.getTag().getName())
+                    .reduce("", (a, b) -> a + b);
+        }
+        return BookDetailResponse.fromEntity(book, tags);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #45 

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 서비스 레이어에서 bookTag 조회하도록 변경

