### PR TITLE
하이라이트에 페이지 번호 함께 저장하도록 수정

### DIFF
--- a/src/main/java/store/storymate/storymatebackend/reading/api/dto/request/HighlightCreateRequest.java
+++ b/src/main/java/store/storymate/storymatebackend/reading/api/dto/request/HighlightCreateRequest.java
@@ -6,7 +6,8 @@ import store.storymate.storymatebackend.reading.domain.MemberBook;
 public record HighlightCreateRequest(
         int startPosition,
         int endPosition,
-        String paragraph
+        String paragraph,
+        int pageNumber
 ) {
     public static Highlight toEntity(MemberBook memberBook, HighlightCreateRequest highlightCreateRequest) {
         return Highlight.builder()
@@ -14,6 +15,7 @@ public record HighlightCreateRequest(
                 .paragraph(highlightCreateRequest.paragraph())
                 .startPosition(highlightCreateRequest.startPosition())
                 .endPosition(highlightCreateRequest.endPosition())
+                .pageNumber(highlightCreateRequest.pageNumber())
                 .build();
     }
 }

--- a/src/main/java/store/storymate/storymatebackend/reading/api/dto/response/HighlightResponse.java
+++ b/src/main/java/store/storymate/storymatebackend/reading/api/dto/response/HighlightResponse.java
@@ -1,9 +1,23 @@
 package store.storymate.storymatebackend.reading.api.dto.response;
 
+import lombok.Builder;
 import store.storymate.storymatebackend.reading.domain.Highlight;
 
-public record HighlightResponse(Long id, String paragraph, int startPosition, int endPosition) {
+@Builder
+public record HighlightResponse(
+        Long id,
+        String paragraph,
+        int startPosition,
+        int endPosition,
+        int pageNumber
+) {
     public static HighlightResponse fromEntity(Highlight highlight) {
-        return new HighlightResponse(highlight.getId(), highlight.getParagraph(), highlight.getStartPosition(), highlight.getEndPosition());
+        return HighlightResponse.builder()
+                .id(highlight.getId())
+                .paragraph(highlight.getParagraph())
+                .startPosition(highlight.getStartPosition())
+                .endPosition(highlight.getEndPosition())
+                .pageNumber(highlight.getPageNumber())
+                .build();
     }
 } 

--- a/src/main/java/store/storymate/storymatebackend/reading/application/MemberBookServiceImpl.java
+++ b/src/main/java/store/storymate/storymatebackend/reading/application/MemberBookServiceImpl.java
@@ -160,7 +160,7 @@ public class MemberBookServiceImpl implements MemberBookService {
         ).orElseThrow(MemberBookNotFoundException::new);
         return highlightRepository.findByMemberBook(memberBook).stream()
                 .map(HighlightResponse::fromEntity)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/src/main/java/store/storymate/storymatebackend/reading/domain/Highlight.java
+++ b/src/main/java/store/storymate/storymatebackend/reading/domain/Highlight.java
@@ -31,6 +31,8 @@ public class Highlight extends BaseEntity {
     @Column(nullable = false)
     private int endPosition;
 
+    private int pageNumber;
+
     @ManyToOne
     @JoinColumn(name = "member_book_id", nullable = false)
     private MemberBook memberBook;
@@ -39,10 +41,12 @@ public class Highlight extends BaseEntity {
     public Highlight(String paragraph,
                      int startPosition,
                      int endPosition,
+                     int pageNumber,
                      MemberBook memberBook) {
         this.paragraph = paragraph;
         this.startPosition = startPosition;
         this.endPosition = endPosition;
+        this.pageNumber = pageNumber;
         this.memberBook = memberBook;
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #26

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 하이라이트 입력 요청 바디에 pageNumber 추가
