### PR TITLE
faet(#48): 채팅 사용시 크래딧 감소 로직 추가 + 퀴즈 정답시 크래딧 증가 로직 추가

### DIFF
--- a/src/main/java/store/storymate/storymatebackend/chatting/application/ChatRoomService.java
+++ b/src/main/java/store/storymate/storymatebackend/chatting/application/ChatRoomService.java
@@ -1,6 +1,7 @@
 package store.storymate.storymatebackend.chatting.application;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -97,5 +98,10 @@ public class ChatRoomService {
                 .orElseThrow(ExistsChatRoomException::new);
 
         return chatRoom.getCharacters().getName();
+    }
+
+    public Optional<ChatRoom> findChatRoomById(Long roomId) {
+        return Optional.ofNullable(chatRoomRepository.findByIdWithMember(roomId)
+                .orElseThrow(ExistsChatRoomException::new));
     }
 }

--- a/src/main/java/store/storymate/storymatebackend/chatting/config/SocketHandler.java
+++ b/src/main/java/store/storymate/storymatebackend/chatting/config/SocketHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
@@ -13,6 +14,10 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import store.storymate.storymatebackend.chatting.api.dto.request.ChatMessageSaveReqDto;
 import store.storymate.storymatebackend.chatting.application.ChatMessageService;
 import store.storymate.storymatebackend.chatting.application.ChatRoomService;
+import store.storymate.storymatebackend.chatting.domain.ChatRoom;
+import store.storymate.storymatebackend.chatting.domain.repository.ChatRoomRepository;
+import store.storymate.storymatebackend.member.application.MemberService;
+import store.storymate.storymatebackend.member.domain.Member;
 
 @Component
 @RequiredArgsConstructor
@@ -21,6 +26,7 @@ public class SocketHandler extends TextWebSocketHandler {
     private final Map<String, List<WebSocketSession>> chatRooms = new HashMap<>();
     private final ChatMessageService chatMessageService;
     private final ChatRoomService chatRoomService;
+    private final MemberService memberService;
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
@@ -36,6 +42,24 @@ public class SocketHandler extends TextWebSocketHandler {
         String roomId = data[1]; // 채팅방 ID
         String bookTitle = data[2]; // 책 제목
         String content = data[3]; // 메시지 내용
+
+        // 0. 메시지를 보낸 사용자의 messageCount 감소
+        Optional<ChatRoom> chatRoomOptional = chatRoomService.findChatRoomById(Long.parseLong(roomId));
+        if (chatRoomOptional.isPresent()) {
+            ChatRoom chatRoom = chatRoomOptional.get();
+            Member member = chatRoom.getMember();
+
+            if (member != null) {
+                Long messageCount = member.getMessageCount(); // ✅ 현재 messageCount 조회
+
+                if (messageCount <= 0) {
+                    session.sendMessage(new TextMessage("⚠️ 메시지를 보낼 수 없습니다. 남은 메시지 횟수가 없습니다."));
+                    return;
+                }
+
+                memberService.decreaseMessageCount(member.getId());
+            }
+        }
 
         // 1. 메시지 저장
         ChatMessageSaveReqDto chatMessageSaveMemberReqDto = 

--- a/src/main/java/store/storymate/storymatebackend/chatting/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/store/storymate/storymatebackend/chatting/domain/repository/ChatRoomRepository.java
@@ -1,9 +1,15 @@
 package store.storymate.storymatebackend.chatting.domain.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import store.storymate.storymatebackend.chatting.domain.ChatRoom;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> , ChatRoomCustomRepository {
+
+    @Query("SELECT c FROM ChatRoom c JOIN FETCH c.member WHERE c.id = :roomId")
+    Optional<ChatRoom> findByIdWithMember(@Param("roomId") Long roomId);
 }

--- a/src/main/java/store/storymate/storymatebackend/member/application/MemberService.java
+++ b/src/main/java/store/storymate/storymatebackend/member/application/MemberService.java
@@ -55,4 +55,9 @@ public class MemberService {
 
         return MemberInfoResponseDto.of(member);
     }
+
+    @Transactional
+    public void decreaseMessageCount(Long memberId) {
+        memberRepository.decrementMessageCount(memberId);
+    }
 }

--- a/src/main/java/store/storymate/storymatebackend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/store/storymate/storymatebackend/member/domain/repository/MemberRepository.java
@@ -1,10 +1,19 @@
 package store.storymate.storymatebackend.member.domain.repository;
 
+import jakarta.transaction.Transactional;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import store.storymate.storymatebackend.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOauthInfoOauthProviderAndOauthInfoOauthId(
             String oauthProvider, String oauthId);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Member m SET m.messageCount = m.messageCount - 1 WHERE m.id = :memberId AND m.messageCount > 0")
+    void decrementMessageCount(@Param("memberId") Long memberId);
 }

--- a/src/main/java/store/storymate/storymatebackend/quiz/api/dto/response/QuizAnswerResDto.java
+++ b/src/main/java/store/storymate/storymatebackend/quiz/api/dto/response/QuizAnswerResDto.java
@@ -1,6 +1,7 @@
 package store.storymate.storymatebackend.quiz.api.dto.response;
 
 public record QuizAnswerResDto(
-        String response
+        String response,
+        String correct
 ) {
 }

--- a/src/main/java/store/storymate/storymatebackend/quiz/application/QuizService.java
+++ b/src/main/java/store/storymate/storymatebackend/quiz/application/QuizService.java
@@ -17,6 +17,7 @@ import store.storymate.storymatebackend.quiz.api.dto.request.QuizAnswerReqDto;
 import store.storymate.storymatebackend.quiz.api.dto.request.QuizQuestionReqDto;
 import store.storymate.storymatebackend.quiz.api.dto.response.QuizAnswerResDto;
 import store.storymate.storymatebackend.quiz.api.dto.response.QuizQuestionResDto;
+import store.storymate.storymatebackend.quiz.domain.CorrectAnswerType;
 import store.storymate.storymatebackend.quiz.exception.AiQuizQuestionException;
 
 @Service
@@ -87,15 +88,14 @@ public class QuizService {
 
         Member member = memberUtil.getCurrentMember();
 
-        if (response != null && isCorrectAnswer(response.correct())) {
-            member.addMessageCount(3L);
+        if (response != null) {
+            CorrectAnswerType answerType = CorrectAnswerType.fromString(response.correct());
+
+            if (answerType != null) {
+                member.addMessageCount(answerType.getPoints());
+            }
         }
 
         return response;
     }
-
-    private boolean isCorrectAnswer(String correct) {
-        return "O".equalsIgnoreCase(correct) || "C".equalsIgnoreCase(correct) || "true".equalsIgnoreCase(correct);
-    }
-
 }

--- a/src/main/java/store/storymate/storymatebackend/quiz/application/QuizService.java
+++ b/src/main/java/store/storymate/storymatebackend/quiz/application/QuizService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
+import store.storymate.storymatebackend.global.util.MemberUtil;
+import store.storymate.storymatebackend.member.domain.Member;
 import store.storymate.storymatebackend.quiz.api.dto.request.QuizAnswerReqDto;
 import store.storymate.storymatebackend.quiz.api.dto.request.QuizQuestionReqDto;
 import store.storymate.storymatebackend.quiz.api.dto.response.QuizAnswerResDto;
@@ -23,6 +25,7 @@ import store.storymate.storymatebackend.quiz.exception.AiQuizQuestionException;
 public class QuizService {
 
     private WebClient webClient;
+    private final MemberUtil memberUtil;
 
     @Value("${ai.characters}")
     private String baseUrl;
@@ -58,7 +61,7 @@ public class QuizService {
                 .block();
     }
 
-    // AI 답변 받는 기능
+    @Transactional
     public QuizAnswerResDto callAiAnswerApi(QuizAnswerReqDto quizQuestionReqDto) {
         Map<String, String> requestBody = new HashMap<>();
         requestBody.put("book_title", quizQuestionReqDto.bookTitle());
@@ -70,7 +73,7 @@ public class QuizService {
                 .encode()
                 .toUriString();
 
-        return webClient.post()
+        QuizAnswerResDto response = webClient.post()
                 .uri(encodedUri)
                 .bodyValue(requestBody)
                 .retrieve()
@@ -81,5 +84,18 @@ public class QuizService {
                 )
                 .bodyToMono(QuizAnswerResDto.class)
                 .block();
+
+        Member member = memberUtil.getCurrentMember();
+
+        if (response != null && isCorrectAnswer(response.correct())) {
+            member.addMessageCount(3L);
+        }
+
+        return response;
     }
+
+    private boolean isCorrectAnswer(String correct) {
+        return "O".equalsIgnoreCase(correct) || "C".equalsIgnoreCase(correct) || "true".equalsIgnoreCase(correct);
+    }
+
 }

--- a/src/main/java/store/storymate/storymatebackend/quiz/domain/CorrectAnswerType.java
+++ b/src/main/java/store/storymate/storymatebackend/quiz/domain/CorrectAnswerType.java
@@ -1,0 +1,24 @@
+package store.storymate.storymatebackend.quiz.domain;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum CorrectAnswerType {
+    O(3L),
+    C(1L),
+    TRUE(2L);
+
+    private final long points;
+
+    CorrectAnswerType(long points) {
+        this.points = points;
+    }
+
+    public static CorrectAnswerType fromString(String value) {
+        return Arrays.stream(values())
+                .filter(type -> type.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
#48

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 웹소켓 상에서 레이지로딩을 해결하기 위해서 애를 썼습니다.. 패치조인이나 update 쿼리를 사용해서 연관관계 객체에 직접 들리지 않도록 설계해 보았습니다. 추후 리팩토링해서 머지하겠습니다.
- 추가로 퀴즈를 어떻게 정답인지 처리할지 고민중에 있습니다.
